### PR TITLE
Implement read receipts

### DIFF
--- a/src/Application/Chat/Events/ChatMessageReceived.cs
+++ b/src/Application/Chat/Events/ChatMessageReceived.cs
@@ -1,0 +1,22 @@
+using FadeChat.Application.Common.Interfaces;
+using FadeChat.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace FadeChat.Application.Chat.Events;
+
+public record ChatMessageReceivedEvent(int MessageId, string ReceiverId) : INotification;
+
+public class ChatMessageReceivedEventHandler(IApplicationDbContext context) : INotificationHandler<ChatMessageReceivedEvent>
+{
+    public async Task Handle(ChatMessageReceivedEvent notification, CancellationToken cancellationToken)
+    {
+        var message = await context.ChatMessages
+            .FirstOrDefaultAsync(x => x.Id == notification.MessageId, cancellationToken);
+
+        if (message != null && message.State == MessageState.Sent)
+        {
+            message.State = MessageState.Received;
+            await context.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Web/ClientApp/src/components/ChatBubble.tsx
+++ b/src/Web/ClientApp/src/components/ChatBubble.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { View, StyleSheet } from "react-native";
 import { Text } from "react-native-paper";
-import { ChatMessageDto } from "../api/client";
+import { ChatMessageDto, MessageState } from "../api/client";
+import { MaterialCommunityIcons } from "../utils/materialIcons";
 import { formatTimestamp } from "../utils/dateTime";
 
 interface ChatBubbleProps {
@@ -39,9 +40,24 @@ const ChatBubble: React.FC<ChatBubbleProps> = ({ message, isOwnMessage }) => {
 				</Text>
 			</View>
 
-			<Text style={styles.timeText}>{formatTimestamp(message.timeStamp)}</Text>
-		</View>
-	);
+                        <View style={styles.footer}>
+                                <Text style={styles.timeText}>{formatTimestamp(message.timeStamp)}</Text>
+                                {isOwnMessage && (
+                                        <MaterialCommunityIcons
+                                                name={
+                                                        message.state === MessageState.Read
+                                                                ? "check-all"
+                                                                : message.state === MessageState.Received
+                                                                ? "check"
+                                                                : "clock"
+                                                }
+                                                size={14}
+                                                color="#888"
+                                        />
+                                )}
+                        </View>
+                </View>
+        );
 };
 
 const styles = StyleSheet.create({
@@ -83,13 +99,19 @@ const styles = StyleSheet.create({
 	otherMessageText: {
 		color: "#000",
 	},
-	timeText: {
-		fontSize: 10,
-		color: "#888",
-		marginTop: 2,
-		alignSelf: "flex-end",
-		marginRight: 4,
-	},
+        timeText: {
+                fontSize: 10,
+                color: "#888",
+                marginTop: 2,
+                alignSelf: "flex-end",
+                marginRight: 4,
+        },
+        footer: {
+                flexDirection: "row",
+                alignItems: "center",
+                alignSelf: "flex-end",
+                gap: 4,
+        },
 });
 
 export default ChatBubble;

--- a/src/Web/ClientApp/src/screens/ChatsListScreen.tsx
+++ b/src/Web/ClientApp/src/screens/ChatsListScreen.tsx
@@ -120,10 +120,13 @@ const ChatsListScreen = () => {
 
 		connectAndSubscribe();
 
-		const handleNewMessage = (message: ChatMessageDto) => {
-			console.log("New message received in ChatsListScreen:", message);
-			setChats((prevChats) => {
-				let chatExists = false;
+                const handleNewMessage = (message: ChatMessageDto) => {
+                        console.log("New message received in ChatsListScreen:", message);
+                        if (message.senderId !== user?.id) {
+                                signalRService.markMessageReceived(message.id);
+                        }
+                        setChats((prevChats) => {
+                                let chatExists = false;
 				const updatedChats = prevChats.map((chat) => {
 					if (chat.id === message.chatId) {
 						chatExists = true;


### PR DESCRIPTION
## Summary
- add read receipt event handler on backend
- implement methods in ChatHub to mark messages received/read
- update SignalR service to expose message status callbacks
- mark messages read/received on the frontend
- display message status in `ChatBubble`

## Testing
- `npx --prefix src/Web/ClientApp tsc -p src/Web/ClientApp/tsconfig.json` *(fails: 403 Forbidden)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447857fadc832296063d4e8469a724